### PR TITLE
Add: tasklist_lock

### DIFF
--- a/dump-phys.c
+++ b/dump-phys.c
@@ -18,9 +18,11 @@ static struct task_struct *name_task_struct(char *name)
 {
     struct task_struct *task;
 
+    read_lock(&tasklist_lock);
     for_each_process(task)
         if (!strcmp(task->comm, name))
             return task;
+    read_unlock(&tasklist_lock);
 
     return NULL;
 }


### PR DESCRIPTION
For_each_process() were called many times by other function of linux kernel and tasklist is often modifed, so we need lock to protect the tasklist. Tasklist_lock is the special lock to protect tasklist in linux kernel. 